### PR TITLE
Implement NFT Registry and Unit Test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,88 @@
-# nft-registry
+# NFT Registry - A meta transactional Non Fungible Token Registry
+
+## Description
+
+The project is to implement a registry using an ERC1155 or ERC721 template from OpenZeppelin.
+
+The registry should allow for the following:
+- Allow user to register [IPFS hash](https://docs.ipfs.io/concepts/hashing/) of some underlying document or folder as a new NFT.
+- Allow user to register a “service” that has a name and points to a collection of NFTs and a single address of an EOA.
+- Has an execute function similar to the one in [ERC725X](https://eips.ethereum.org/EIPS/eip-725) plus an additional argument which is the “service” name. This function checks that the tx it receives is signed by the EOA which is registered for the service and then makes the contract to contract call specified.
+
+## Configuration
+
+### Install Truffle cli
+
+_Skip if you have already installed._
+
+```
+npm install -g truffle
+```
+
+### Install Dependencies
+
+```
+npm install
+```
+
+## Test!💥
+
+### Run Tests
+
+Launch Ganache then run:
+
+```
+npm run test
+```
+
+or test in truffle console
+
+```
+truffle(develop)> test
+Using network 'develop'.
+
+
+Compiling your contracts...
+===========================
+> Everything is up to date, there is nothing to compile.
+
+
+
+  Contract: Registry
+    Metadata
+      √ should get name (172ms)
+      √ should get symbol (136ms)
+    Meta-transaction
+      √ should verify signature (405ms)
+      √ should revert when an invalid signer provided (681ms)
+    Service
+      register
+        √ should register a service (378ms)
+        √ should revert if the service exists already (841ms)
+      unregister
+        √ should unregister a service (762ms)
+        √ should revert if the service doesn't exist (483ms)
+        √ should revert when the signer has no permission (817ms)
+    Token
+      register
+        √ should register a token (571ms)
+        √ should register a token and add to a service (1136ms)
+        √ should revert if the given service doesn't exist (406ms)
+      unregister
+        √ should unregister a token (1001ms)
+        √ should revert if the token doesn't exist (564ms)
+        √ should revert when the signer has no permission (735ms)
+    Token-Service Relationship
+      √ should use a token for a service (1326ms)
+      √ should revert if the service doesn't exist (807ms)
+      √ should unuse a token for a service (1809ms)
+      √ should revert if the token doesn't exist (1040ms)
+    execute
+      √ should revert if the signer has no permission (1009ms)
+      √ should revert if the unsupported operation requested (954ms)
+      √ should external call (1067ms)
+
+
+  22 passing (31s)
+
+```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 The project is to implement a registry using an ERC1155 or ERC721 template from OpenZeppelin.
 
 The registry should allow for the following:
+
 - Allow user to register [IPFS hash](https://docs.ipfs.io/concepts/hashing/) of some underlying document or folder as a new NFT.
 - Allow user to register a “service” that has a name and points to a collection of NFTs and a single address of an EOA.
 - Has an execute function similar to the one in [ERC725X](https://eips.ethereum.org/EIPS/eip-725) plus an additional argument which is the “service” name. This function checks that the tx it receives is signed by the EOA which is registered for the service and then makes the contract to contract call specified.

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -1,0 +1,457 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.6 <0.9.0;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "./libs/String.sol";
+import "./libs/Bytes32.sol";
+
+/**
+ * @dev NFT Registry
+ *
+ * Implements ERC721.
+ * name:    Valory Registry
+ * symbol:  VRT
+ *
+ * It registers(mint) NFT using it's IFPS hash as token ID.
+ * It registers Service that is a collection of NFTs.
+ * It executes Service as requested.
+ *
+ * @notice All external functions accept meta-transactions.
+ * The owner sends the transactions behind the signers, every external function is only callable by the owner.
+ * Accounts must provide the signature and signer, but it doesn't implement EIP-712.
+ * Thus, accounts must provide the transaction message configured based on the each individual function implementation.
+ *
+ * @notice Token has multi to multi polymorphic relationship to Service.
+ */
+contract Registry is ERC721("Valory Registry", "VRT"), Ownable {
+  /* Constructor */
+
+  /* Events */
+  /**
+   * @dev Occurs when a new service is registered.
+   *
+   * @param name  - The service name
+   * @param owner - The service owner
+   */
+  event ServiceRegistered(string indexed name, address indexed owner);
+
+  /**
+   * @dev Occurs when a new service is unregistered.
+   *
+   * @param name  - The service name
+   * @param owner - The service owner
+   */
+  event ServiceUnregistered(string indexed name, address indexed owner);
+
+  /**
+   * @dev Occurs when a token is used for a service.
+   *
+   * @param tokenId     - The token id
+   * @param serviceName - The service name
+   */
+  event TokenUsed(bytes32 indexed tokenId, string indexed serviceName);
+
+  /**
+   * @dev Occurs when a token is unused for a service.
+   *
+   * @param tokenId     - The token id
+   * @param serviceName - The service name
+   */
+  event TokenUnused(bytes32 indexed tokenId, string indexed serviceName);
+
+  /* Constancs */
+  /// @dev The external operation types.
+  uint256 private constant OPERATION_CALL = 0;
+  uint256 private constant OPERATION_DELEGATECALL = 1;
+  uint256 private constant OPERATION_CREATE2 = 2;
+  uint256 private constant OPERATION_CREATE = 3;
+
+  /* Libraries */
+  /// @notice Use libraries to handle multi to multi relationship.
+  using EnumerableSet for EnumerableSet.Bytes32Set;
+  using String for string;
+  using Bytes32 for bytes32;
+
+  /* Data Struct */
+  /// @dev Service struct represents the registered services.
+  struct Service {
+    address owner; // The EOA who owned the service
+    EnumerableSet.Bytes32Set tokenIds; // The collection of token Ids that belong to the service
+  }
+
+  /* State Variables */
+  /// @dev The map of services by the service name as the key.
+  mapping(string => Service) private services;
+
+  /// @dev The map of services by the token Id as the key.
+  /// @notice A token can be used for multiple services.
+  mapping(bytes32 => EnumerableSet.Bytes32Set) private uses;
+
+  /// @dev The nonces used for recovering signer, prevents replay attack.
+  mapping(address => uint256) public nonces;
+
+  /* Modifiers */
+  /// @dev Restricts the length of string to be less than or equal to the given length.
+  modifier lengthedString(string calldata name, uint256 length) {
+    require(bytes(name).length <= length, "VRT: String length exceeds the limitation");
+    _;
+  }
+
+  /**
+   * @dev Restricts the function to be called when the transaction has been signed by a valid signer.
+   * Increases the nonce of the signer on validation success.
+   */
+  modifier validSign(
+    bytes32 message,
+    bytes memory signature,
+    address signer
+  ) {
+    message = keccak256(abi.encodePacked(nonces[signer], message));
+    require(_recoverSigner(message, signature) == signer, "VRT: Invalid signer");
+    nonces[signer]++;
+    _;
+  }
+
+  /* Public Functions */
+  /**
+   * @dev Registers a service and set the caller to the owner.
+   * Reverts if the service was registered already.
+   * Emits ServiceRegistered on completion.
+   *
+   * @param name - The name of the service being registered, limited to be less than or equal 32 bytes,
+   * as the name is used for resolving token to service relationship as bytes32 type
+   * @param signature   - The signature
+   * @param signer      - The signer of the transaction
+   */
+  function registerService(
+    string calldata name,
+    bytes calldata signature,
+    address signer
+  ) external onlyOwner lengthedString(name, 32) validSign(keccak256(abi.encodePacked(name)), signature, signer) {
+    require(!_serviceExists(name), "VRT: Service already exist");
+
+    services[name].owner = signer;
+
+    emit ServiceRegistered(name, signer);
+  }
+
+  /**
+   * @dev Unregisters a service and releases all used tokens.
+   * Reverts if the service was not found, or when the sender is not the owner.
+   * Emits ServiceUnregistered on completion.
+   *
+   * @param name        - The name of the service being unregistered
+   * @param signature   - The signature
+   * @param signer      - The signer of the transaction
+   */
+  function unregisterSerivce(
+    string calldata name,
+    bytes calldata signature,
+    address signer
+  ) external onlyOwner validSign(keccak256(abi.encodePacked(name)), signature, signer) {
+    require(_serviceExists(name), "VRT: Service not found");
+    Service storage service = services[name];
+    address owner = service.owner;
+    require(owner == signer, "VRT: No permission");
+
+    // remove token to service relationships.
+    EnumerableSet.Bytes32Set storage tokenIds = service.tokenIds;
+    uint256 length = tokenIds.length();
+    for (uint256 i = 0; i < length; i++) {
+      uses[tokenIds.at(i)].remove(name.toBytes32());
+    }
+
+    // remove service to token relationships.
+    delete services[name];
+
+    emit ServiceUnregistered(name, owner);
+  }
+
+  /**
+   * @dev Registers(mint) a token.
+   * Emits Transfer on completion.
+   *
+   * @param to          - The address of the owner of the token being newly registered
+   * @param tokenId     - The IFPS hash of the asset
+   * @param signature   - The signature
+   * @param signer      - The signer of the transaction
+   */
+  function registerToken(
+    address to,
+    bytes32 tokenId,
+    bytes calldata signature,
+    address signer
+  ) public onlyOwner validSign(keccak256(abi.encodePacked(to, tokenId)), signature, signer) {
+    _safeMint(to, tokenId.toUint());
+  }
+
+  /**
+   * @dev Registers(mint) a token and add to a service.
+   * Reverts if the service doesn't exist.
+   * Emits Transfer, TokenUsed on completion.
+   *
+   * @param to          - The address of the owner of the token being newly registered
+   * @param tokenId     - The IFPS hash of the asset
+   * @param serviceName - The service name which uses the token
+   * @param signature   - The signature
+   * @param signer      - The signer of the transaction
+   */
+  function registerToken(
+    address to,
+    bytes32 tokenId,
+    string calldata serviceName,
+    bytes calldata signature,
+    address signer
+  ) external onlyOwner validSign(keccak256(abi.encodePacked(to, tokenId, serviceName)), signature, signer) {
+    require(_serviceExists(serviceName), "VRT: Service not found");
+
+    _safeMint(to, tokenId.toUint());
+
+    _useToken(tokenId, serviceName);
+  }
+
+  /**
+   * @dev Unregisters(burn) a token and removes from services.
+   * Reverts if the token doesn't exist, or the caller is not the owner.
+   * Emits Transfer on completion.
+   *
+   * @param tokenId     - The IFPS hash of the asset
+   * @param signature   - The signature
+   * @param signer      - The signer of the transaction
+   */
+  function unregisterToken(
+    bytes32 tokenId,
+    bytes calldata signature,
+    address signer
+  ) external onlyOwner validSign(keccak256(abi.encodePacked(tokenId)), signature, signer) {
+    uint256 uId = tokenId.toUint();
+    require(_exists(uId), "VRT: Token not found");
+    require(ownerOf(uId) == signer, "VRT: No permission");
+
+    _burn(uId);
+
+    // remove service to token relationships.
+    EnumerableSet.Bytes32Set storage usedServiceNames = uses[tokenId];
+    uint256 length = usedServiceNames.length();
+    for (uint256 i = 0; i < length; ++i) {
+      services[usedServiceNames.at(i).toString()].tokenIds.remove(tokenId);
+    }
+
+    // remove token to service relationships.
+    delete uses[tokenId];
+  }
+
+  /**
+   * @dev Adds a token to a service.
+   * Emits TokenUsed on completion.
+   *
+   * @param tokenId     - The IFPS hash of the asset
+   * @param serviceName - The service name which uses the token
+   * @param signature   - The signature
+   * @param signer      - The signer of the transaction
+   */
+  function useToken(
+    bytes32 tokenId,
+    string calldata serviceName,
+    bytes calldata signature,
+    address signer
+  ) external onlyOwner validSign(keccak256(abi.encodePacked(tokenId, serviceName)), signature, signer) {
+    require(_serviceExists(serviceName), "VRT: Service not found");
+    uint256 uId = tokenId.toUint();
+    require(_exists(uId), "VRT: Token not found");
+    require(ownerOf(uId) == signer, "VRT: No permission");
+    require(!_tokenUsed(tokenId, serviceName), "VRT: Token already is used");
+
+    _useToken(tokenId, serviceName);
+  }
+
+  /**
+   * @dev Removes a token from a service.
+   * Emits TokenUnused on completion.
+   *
+   * @param tokenId     - The IFPS hash of the asset
+   * @param serviceName - The service name which uses the token
+   * @param signature   - The signature
+   * @param signer      - The signer of the transaction
+   */
+  function unuseToken(
+    bytes32 tokenId,
+    string calldata serviceName,
+    bytes calldata signature,
+    address signer
+  ) external onlyOwner validSign(keccak256(abi.encodePacked(tokenId, serviceName)), signature, signer) {
+    require(_serviceExists(serviceName), "VRT: Service not found");
+    uint256 uId = tokenId.toUint();
+    require(_exists(uId), "VRT: Token not found");
+    require(ownerOf(uId) == signer, "VRT: No permission");
+    require(_tokenUsed(tokenId, serviceName), "VRT: Token was not used");
+
+    _unuseToken(tokenId, serviceName);
+  }
+
+  /**
+   * @dev Executes any other smart contract. Is only callable by the owner.
+   * Reverts if the signer has no permission to do.
+   *
+   * @param operation   - The operation to execute, only supports call: CALL = 0; DELEGATECALL = 1; CREATE2 = 2; CREATE = 3;
+   * @param to          - The external smart contract
+   * @param value       - The value of Ether to transfer
+   * @param data        - The call data
+   * @param serviceName - The service name used to validate the permission of the signer
+   * @param signature   - The signature
+   * @param signer      - The signer of the transaction
+   */
+  function execute(
+    uint256 operation,
+    address to,
+    uint256 value,
+    bytes calldata data,
+    string calldata serviceName,
+    bytes calldata signature,
+    address signer
+  ) external payable onlyOwner validSign(keccak256(abi.encodePacked(operation, to, value, data, serviceName)), signature, signer) {
+    require(services[serviceName].owner == signer, "VRT: No permission");
+
+    // build error data
+    bytes memory unsupportedOpErrData = abi.encodeWithSignature("Error(string)", "VRT: Unsupported operation"); // less than 32 bytes
+
+    assembly {
+      // only supports CALL operation, otherwise reverts
+      if eq(xor(operation, OPERATION_CALL), 1) {
+        revert(add(unsupportedOpErrData, 0x20), mload(unsupportedOpErrData))
+      }
+    }
+
+    // make external call, with limited amount of gas.
+    _executeCall(to, value, gasleft() - 2500, data); // Used to avoid stack too deep error.
+  }
+
+  /* Private Functions */
+  /**
+   * @dev Recovers the signer of the transaction.
+   * Reverts if invalid signature was provided.
+   *
+   * @param message   - The transaction message consists of parameters
+   * @param signature - The signature of the transaction
+   * @return signer   - The valid signer of the transaction
+   */
+  function _recoverSigner(bytes32 message, bytes memory signature) private pure returns (address signer) {
+    require(signature.length == 65, "VRT: Invalid signature length");
+
+    // build a prefixed hash to mimic the behavior of eth_sign.
+    message = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", message));
+
+    // recover signer
+    uint8 v;
+    bytes32 r;
+    bytes32 s;
+    assembly {
+      // first 32 bytes, after the length prefix.
+      r := mload(add(signature, 32))
+      // second 32 bytes.
+      s := mload(add(signature, 64))
+      // final byte (first byte of the next 32 bytes).
+      v := byte(0, mload(add(signature, 96)))
+    }
+    // require(
+    //     uint256(s) <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0,
+    //     "ECDSA: invalid signature 's' value"
+    // );
+    // require(v == 27 || v == 28, "ECDSA: invalid signature 'v' value");
+
+    signer = ecrecover(message, v, r, s);
+
+    /// @notice Invalid signatures will produce an empty address.
+    require(signer != address(0), "VRT: Invalid signature");
+  }
+
+  /**
+   * @dev Executes external contract call.
+   * Returns data returned from the external contract if the call was successful, otherwise reverts.
+   *
+   * @param to    - The address of the external contract being called
+   * @param value - The value of Ether to transfer
+   * @param gasTo - The amount gas allowed for the external contract
+   * @param data  - The call data
+   */
+  function _executeCall(
+    address to,
+    uint256 value,
+    uint256 gasTo,
+    bytes memory data
+  ) private {
+    assembly {
+      // call external contract.
+      let result := call(gasTo, to, value, add(data, 0x20), mload(data), 0, 0)
+
+      // alloc memory for returned data.
+      let pos := mload(0x40)
+      let len := returndatasize()
+      mstore(0x40, add(pos, len))
+      // copy the returned data.
+      returndatacopy(pos, 0, len)
+
+      switch result
+      // call returns 0 on error.
+      case 0 {
+        revert(pos, len)
+      }
+      default {
+        return(pos, len)
+      }
+    }
+  }
+
+  /**
+   * @dev Checks if the service of name exists.
+   *
+   * @param name - The service name
+   * @return true if the service of name exists, otherwise false
+   */
+  function _serviceExists(string calldata name) private view returns (bool) {
+    return services[name].owner != address(0);
+  }
+
+  /**
+   * @dev Checks if the token is used for the service.
+   *
+   * @param tokenId     - The IFPS hash of the asset
+   * @param serviceName - The service name which uses the token
+   * @return true if the token is used for the service of name, otherwise false
+   */
+  function _tokenUsed(bytes32 tokenId, string calldata serviceName) private view returns (bool) {
+    return uses[tokenId].contains(serviceName.toBytes32());
+  }
+
+  /**
+   * @dev Adds a token to a service.
+   *
+   * @param tokenId     - The IFPS hash of the asset
+   * @param serviceName - The service name which uses the token
+   */
+  function _useToken(bytes32 tokenId, string calldata serviceName) private {
+    // add service to token relationship.
+    services[serviceName].tokenIds.add(tokenId);
+    // add token to service relationship.
+    uses[tokenId].add(serviceName.toBytes32());
+
+    emit TokenUsed(tokenId, serviceName);
+  }
+
+  /**
+   * @dev Removes a token from a service.
+   *
+   * @param tokenId     - The IFPS hash of the asset
+   * @param serviceName - The service name which uses the token
+   */
+  function _unuseToken(bytes32 tokenId, string calldata serviceName) private {
+    // remove service to token relationship.
+    services[serviceName].tokenIds.remove(tokenId);
+    // remove token to service relationship.
+    uses[tokenId].remove(serviceName.toBytes32());
+
+    emit TokenUnused(tokenId, serviceName);
+  }
+}

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -51,7 +51,7 @@ contract Registry is ERC721("Valory Registry", "VRT"), Ownable {
    * @param tokenId     - The token id
    * @param serviceName - The service name
    */
-  event TokenUsed(bytes32 indexed tokenId, string indexed serviceName);
+  event TokenUsed(bytes32 indexed tokenId, string serviceName);
 
   /**
    * @dev Occurs when a token is unused for a service.
@@ -59,7 +59,7 @@ contract Registry is ERC721("Valory Registry", "VRT"), Ownable {
    * @param tokenId     - The token id
    * @param serviceName - The service name
    */
-  event TokenUnused(bytes32 indexed tokenId, string indexed serviceName);
+  event TokenUnused(bytes32 indexed tokenId, string serviceName);
 
   /* Constancs */
   /// @dev The external operation types.
@@ -132,7 +132,7 @@ contract Registry is ERC721("Valory Registry", "VRT"), Ownable {
    * @param signature   - The signature
    * @param signer      - The signer of the transaction
    */
-  function unregisterSerivce(
+  function unregisterService(
     string calldata name,
     bytes calldata signature,
     address signer

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -23,7 +23,7 @@ import "./libs/Bytes32.sol";
  * Accounts must provide the signature and signer, but it doesn't implement EIP-712.
  * Thus, accounts must provide the transaction message configured based on the each individual function implementation.
  *
- * @notice Token has multi to multi polymorphic relationship to Service.
+ * @notice Token has many to many relationship to Service.
  */
 contract Registry is ERC721("Valory Registry", "VRT"), Ownable {
   /* Constructor */
@@ -69,7 +69,7 @@ contract Registry is ERC721("Valory Registry", "VRT"), Ownable {
   uint256 private constant OPERATION_CREATE = 3;
 
   /* Libraries */
-  /// @notice Use libraries to handle multi to multi relationship.
+  /// @notice Use libraries to handle many to many relationship.
   using EnumerableSet for EnumerableSet.Bytes32Set;
   using String for string;
   using Bytes32 for bytes32;

--- a/contracts/libs/Bytes32.sol
+++ b/contracts/libs/Bytes32.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.6;
+
+library Bytes32 {
+  function toString(bytes32 value) internal pure returns (string memory) {
+    return string(bytes.concat(value));
+  }
+
+  function toUint(bytes32 value) internal pure returns (uint256) {
+    return uint256(value);
+  }
+}

--- a/contracts/libs/String.sol
+++ b/contracts/libs/String.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.6;
+
+library String {
+  function toBytes32(string memory value) internal pure returns (bytes32) {
+    return bytes32(bytes(value));
+  }
+}

--- a/contracts/mock/ExternalMock.sol
+++ b/contracts/mock/ExternalMock.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.6 <0.9.0;
+
+contract ExternalMock {
+  string public bar;
+
+  function foo(string memory value) external payable returns (bool) {
+    bar = value;
+    return true;
+  }
+}

--- a/migrations/1628594322_registry.js
+++ b/migrations/1628594322_registry.js
@@ -1,0 +1,6 @@
+const Registry = artifacts.require("Registry");
+
+module.exports = function (_deployer, _, [_owner]) {
+  // Use deployer to state migration tasks.
+  _deployer.deploy(Registry, { from: _owner });
+};

--- a/migrations/1628620839_external_mock.js
+++ b/migrations/1628620839_external_mock.js
@@ -1,0 +1,6 @@
+const ExternalMock = artifacts.require("ExternalMock");
+
+module.exports = function (_deployer) {
+  // Use deployer to state migration tasks.
+  _deployer.deploy(ExternalMock);
+};

--- a/test/registry.js
+++ b/test/registry.js
@@ -1,7 +1,10 @@
 const Registry = artifacts.require("Registry");
+const ExternalMock = artifacts.require("ExternalMock");
+
 const { expect } = require("chai");
-const { BN, expectEvent } = require("@openzeppelin/test-helpers");
+const { BN, expectEvent, expectRevert } = require("@openzeppelin/test-helpers");
 const { web3 } = require("@openzeppelin/test-helpers/src/setup");
+const { ZERO_ADDRESS } = require("@openzeppelin/test-helpers/src/constants");
 
 /*
  * uncomment accounts to access the test accounts made available by the
@@ -9,28 +12,39 @@ const { web3 } = require("@openzeppelin/test-helpers/src/setup");
  * See docs: https://www.trufflesuite.com/docs/truffle/testing/writing-tests-in-javascript
  */
 async function sign(nonce, signer, ...data) {
-  console.log("signed data", data);
-  let hash = web3.utils.soliditySha3(...data); // remove 0x prefix
-  console.log("hash1", hash, nonce.toString());
-  console.log("hash11", web3.utils.soliditySha3({ t: "string", v: "service1" }));
+  let hash = web3.utils.soliditySha3(...data);
   hash = web3.utils.soliditySha3({ t: "uint256", v: nonce }, { t: "bytes32", v: hash });
-  console.log("hash2", hash);
-  // hash = web3.utils.soliditySha3({t: "string", v: "\x19Ethereum Signed Message:\n32"}, {t: "bytes32", v: hash});
-  // console.log('hash3', hash)
   return await web3.eth.sign(hash, signer);
 }
 
+function encodeMockFunctionCall(value) {
+  return web3.eth.abi.encodeFunctionCall(
+    {
+      name: "foo",
+      type: "function",
+      inputs: [
+        {
+          type: "string",
+          name: "value",
+        },
+      ],
+    },
+    [value],
+  );
+}
+
 contract("Registry", function ([_owner, _signer]) {
+  const serviceNames = ["service1", "service2"];
+  const tokenIds = [web3.utils.randomHex(32), web3.utils.randomHex(32), web3.utils.randomHex(32)];
   let registry;
-  let signer;
-  const password = "password";
+  let mock;
+
   beforeEach(async function () {
-    registry = await Registry.deployed();
-    // signer = await web3.eth.personal.newAccount(password);
-    // console.log("new account", signer)
+    registry = await Registry.new();
+    mock = await ExternalMock.new();
   });
 
-  context("Meta", function () {
+  context("Metadata", function () {
     it("should get name", async function () {
       expect(await registry.name()).to.be.equal("Valory Registry");
     });
@@ -40,18 +54,400 @@ contract("Registry", function ([_owner, _signer]) {
     });
   });
 
-  context("Service", function () {
-    it("should register a service", async function () {
-      const serviceName = "service1";
-      const signature = await sign(await registry.nonces(_signer), _signer, { t: "string", v: serviceName });
-      console.log("signature", signature);
-      const result = await registry.registerService(serviceName, signature, _signer);
-      console.log("result", result);
+  context("Meta-transaction", function () {
+    it("should verify signature", async function () {
+      const result = await registry.registerService(
+        serviceNames[0],
+        await sign(await registry.nonces(_signer), _signer, { t: "string", v: serviceNames[0] }),
+        _signer,
+      );
       expect(result.receipt.status).to.be.equal(true);
-      expectEvent(result.receipt, "ServiceRegistered", {
-        name: serviceName,
-        owner: _signer,
+    });
+
+    it("should revert when an invalid signer provided", async function () {
+      await expectRevert(
+        registry.registerService(
+          serviceNames[0],
+          await sign(await registry.nonces(_signer), _signer, { t: "string", v: serviceNames[0] }),
+          _owner,
+        ),
+        "VRT: Invalid signer",
+      );
+    });
+  });
+
+  context("Service", function () {
+    context("register", function () {
+      it("should register a service", async function () {
+        const result = await registry.registerService(
+          serviceNames[0],
+          await sign(await registry.nonces(_signer), _signer, { t: "string", v: serviceNames[0] }),
+          _signer,
+        );
+        expect(result.receipt.status).to.be.equal(true);
+        expectEvent(result, "ServiceRegistered", {
+          name: serviceNames[0],
+          owner: _signer,
+        });
       });
+
+      it("should revert if the service exists already", async function () {
+        await registry.registerService(
+          serviceNames[0],
+          await sign(await registry.nonces(_signer), _signer, { t: "string", v: serviceNames[0] }),
+          _signer,
+        );
+        await expectRevert(
+          registry.registerService(
+            serviceNames[0],
+            await sign(await registry.nonces(_signer), _signer, { t: "string", v: serviceNames[0] }),
+            _signer,
+          ),
+          "VRT: Service already exist",
+        );
+      });
+    });
+
+    context("unregister", function () {
+      it("should unregister a service", async function () {
+        await registry.registerService(
+          serviceNames[0],
+          await sign(await registry.nonces(_signer), _signer, { t: "string", v: serviceNames[0] }),
+          _signer,
+        );
+        const result = await registry.unregisterService(
+          serviceNames[0],
+          await sign(await registry.nonces(_signer), _signer, { t: "string", v: serviceNames[0] }),
+          _signer,
+        );
+        expect(result.receipt.status).to.be.equal(true);
+        expectEvent(result, "ServiceUnregistered", {
+          name: serviceNames[0],
+          owner: _signer,
+        });
+      });
+
+      it("should revert if the service doesn't exist", async function () {
+        await expectRevert(
+          registry.unregisterService(
+            serviceNames[0],
+            await sign(await registry.nonces(_signer), _signer, { t: "string", v: serviceNames[0] }),
+            _signer,
+          ),
+          "VRT: Service not found",
+        );
+      });
+
+      it("should revert when the signer has no permission", async function () {
+        await registry.registerService(
+          serviceNames[0],
+          await sign(await registry.nonces(_owner), _owner, { t: "string", v: serviceNames[0] }),
+          _owner,
+        );
+        await expectRevert(
+          registry.unregisterService(
+            serviceNames[0],
+            await sign(await registry.nonces(_signer), _signer, { t: "string", v: serviceNames[0] }),
+            _signer,
+          ),
+          "VRT: No permission",
+        );
+      });
+    });
+  });
+
+  context("Token", function () {
+    context("register", function () {
+      it("should register a token", async function () {
+        const result = await registry.registerToken(
+          _signer,
+          tokenIds[0],
+          await sign(await registry.nonces(_signer), _signer, { t: "address", v: _signer }, { t: "bytes32", v: tokenIds[0] }),
+          _signer,
+        );
+        expect(result.receipt.status).to.be.equal(true);
+        expectEvent(result, "Transfer", {
+          from: ZERO_ADDRESS,
+          to: _signer,
+          tokenId: web3.utils.toBN(tokenIds[0]),
+        });
+        expect(await registry.ownerOf(tokenIds[0])).to.be.equal(_signer);
+      });
+
+      it("should register a token and add to a service", async function () {
+        await registry.registerService(
+          serviceNames[0],
+          await sign(await registry.nonces(_signer), _signer, { t: "string", v: serviceNames[0] }),
+          _signer,
+        );
+        const result = await registry.registerToken(
+          _signer,
+          tokenIds[0],
+          serviceNames[0],
+          await sign(
+            await registry.nonces(_signer),
+            _signer,
+            { t: "address", v: _signer },
+            { t: "bytes32", v: tokenIds[0] },
+            { t: "string", v: serviceNames[0] },
+          ),
+          _signer,
+        );
+        expect(result.receipt.status).to.be.equal(true);
+        expectEvent(result, "TokenUsed", {
+          tokenId: tokenIds[0],
+          serviceName: serviceNames[0],
+        });
+        expect(await registry.ownerOf(tokenIds[0])).to.be.equal(_signer);
+      });
+
+      it("should revert if the given service doesn't exist", async function () {
+        await expectRevert(
+          registry.registerToken(
+            _signer,
+            tokenIds[0],
+            serviceNames[0],
+            await sign(
+              await registry.nonces(_signer),
+              _signer,
+              { t: "address", v: _signer },
+              { t: "bytes32", v: tokenIds[0] },
+              { t: "string", v: serviceNames[0] },
+            ),
+            _signer,
+          ),
+          "VRT: Service not found",
+        );
+      });
+    });
+
+    context("unregister", function () {
+      it("should unregister a token", async function () {
+        await registry.registerToken(
+          _signer,
+          tokenIds[0],
+          await sign(await registry.nonces(_signer), _signer, { t: "address", v: _signer }, { t: "bytes32", v: tokenIds[0] }),
+          _signer,
+        );
+        const result = await registry.unregisterToken(
+          tokenIds[0],
+          await sign(await registry.nonces(_signer), _signer, { t: "bytes32", v: tokenIds[0] }),
+          _signer,
+        );
+        expect(result.receipt.status).to.be.equal(true);
+        expectEvent(result, "Transfer", {
+          from: _signer,
+          to: ZERO_ADDRESS,
+          tokenId: web3.utils.toBN(tokenIds[0]),
+        });
+        await expectRevert(registry.ownerOf(tokenIds[0]), "ERC721: owner query for nonexistent token");
+      });
+
+      it("should revert if the token doesn't exist", async function () {
+        await expectRevert(
+          registry.unregisterToken(tokenIds[0], await sign(await registry.nonces(_signer), _signer, { t: "bytes32", v: tokenIds[0] }), _signer),
+          "VRT: Token not found",
+        );
+      });
+
+      it("should revert when the signer has no permission", async function () {
+        await registry.registerToken(
+          _owner,
+          tokenIds[0],
+          await sign(await registry.nonces(_owner), _owner, { t: "address", v: _owner }, { t: "bytes32", v: tokenIds[0] }),
+          _owner,
+        );
+        await expectRevert(
+          registry.unregisterToken(tokenIds[0], await sign(await registry.nonces(_signer), _signer, { t: "bytes32", v: tokenIds[0] }), _signer),
+          "VRT: No permission",
+        );
+      });
+    });
+  });
+
+  context("Token-Service Relationship", function () {
+    it("should use a token for a service", async function () {
+      await registry.registerService(
+        serviceNames[0],
+        await sign(await registry.nonces(_signer), _signer, { t: "string", v: serviceNames[0] }),
+        _signer,
+      );
+      await registry.registerToken(
+        _signer,
+        tokenIds[0],
+        await sign(await registry.nonces(_signer), _signer, { t: "address", v: _signer }, { t: "bytes32", v: tokenIds[0] }),
+        _signer,
+      );
+      const result = await registry.useToken(
+        tokenIds[0],
+        serviceNames[0],
+        await sign(await registry.nonces(_signer), _signer, { t: "bytes32", v: tokenIds[0] }, { t: "string", v: serviceNames[0] }),
+        _signer,
+      );
+      expect(result.receipt.status).to.be.equal(true);
+      expectEvent(result, "TokenUsed", {
+        tokenId: tokenIds[0],
+        serviceName: serviceNames[0],
+      });
+    });
+
+    it("should revert if the service doesn't exist", async function () {
+      await registry.registerToken(
+        _signer,
+        tokenIds[0],
+        await sign(await registry.nonces(_signer), _signer, { t: "address", v: _signer }, { t: "bytes32", v: tokenIds[0] }),
+        _signer,
+      );
+      await expectRevert(
+        registry.useToken(
+          tokenIds[0],
+          serviceNames[0],
+          await sign(await registry.nonces(_signer), _signer, { t: "bytes32", v: tokenIds[0] }, { t: "string", v: serviceNames[0] }),
+          _signer,
+        ),
+        "VRT: Service not found",
+      );
+    });
+
+    it("should unuse a token for a service", async function () {
+      await registry.registerService(
+        serviceNames[0],
+        await sign(await registry.nonces(_signer), _signer, { t: "string", v: serviceNames[0] }),
+        _signer,
+      );
+      await registry.registerToken(
+        _signer,
+        tokenIds[0],
+        await sign(await registry.nonces(_signer), _signer, { t: "address", v: _signer }, { t: "bytes32", v: tokenIds[0] }),
+        _signer,
+      );
+      await registry.useToken(
+        tokenIds[0],
+        serviceNames[0],
+        await sign(await registry.nonces(_signer), _signer, { t: "bytes32", v: tokenIds[0] }, { t: "string", v: serviceNames[0] }),
+        _signer,
+      );
+      const result = await registry.unuseToken(
+        tokenIds[0],
+        serviceNames[0],
+        await sign(await registry.nonces(_signer), _signer, { t: "bytes32", v: tokenIds[0] }, { t: "string", v: serviceNames[0] }),
+        _signer,
+      );
+      expect(result.receipt.status).to.be.equal(true);
+      expectEvent(result, "TokenUnused", {
+        tokenId: tokenIds[0],
+        serviceName: serviceNames[0],
+      });
+    });
+
+    it("should revert if the token doesn't exist", async function () {
+      await registry.registerService(
+        serviceNames[0],
+        await sign(await registry.nonces(_signer), _signer, { t: "string", v: serviceNames[0] }),
+        _signer,
+      );
+      await expectRevert(
+        registry.unuseToken(
+          tokenIds[0],
+          serviceNames[0],
+          await sign(await registry.nonces(_signer), _signer, { t: "bytes32", v: tokenIds[0] }, { t: "string", v: serviceNames[0] }),
+          _signer,
+        ),
+        "VRT: Token not found",
+      );
+    });
+  });
+
+  const OPERATION_CALL = 0;
+  const OPERATION_DELEGATECALL = 1;
+  context("execute", function () {
+    it("should revert if the signer has no permission", async function () {
+      await registry.registerService(
+        serviceNames[0],
+        await sign(await registry.nonces(_signer), _signer, { t: "string", v: serviceNames[0] }),
+        _signer,
+      );
+      const data = encodeMockFunctionCall("😂");
+      await expectRevert(
+        registry.execute(
+          OPERATION_CALL,
+          mock.address,
+          0,
+          data,
+          serviceNames[0],
+          await sign(
+            await registry.nonces(_owner),
+            _owner,
+            { t: "uint256", v: OPERATION_CALL },
+            { t: "address", v: mock.address },
+            { t: "uint256", v: 0 },
+            { t: "bytes", v: data },
+            { t: "string", v: serviceNames[0] },
+          ),
+          _owner,
+        ),
+        "VRT: No permission",
+      );
+    });
+
+    it("should revert if the unsupported operation requested", async function () {
+      await registry.registerService(
+        serviceNames[0],
+        await sign(await registry.nonces(_signer), _signer, { t: "string", v: serviceNames[0] }),
+        _signer,
+      );
+      const data = encodeMockFunctionCall("😂");
+      await expectRevert(
+        registry.execute(
+          OPERATION_DELEGATECALL,
+          mock.address,
+          0,
+          data,
+          serviceNames[0],
+          await sign(
+            await registry.nonces(_signer),
+            _signer,
+            { t: "uint256", v: OPERATION_DELEGATECALL },
+            { t: "address", v: mock.address },
+            { t: "uint256", v: 0 },
+            { t: "bytes", v: data },
+            { t: "string", v: serviceNames[0] },
+          ),
+          _signer,
+        ),
+        "VRT: Unsupported operation",
+      );
+    });
+
+    it("should external call", async function () {
+      await registry.registerService(
+        serviceNames[0],
+        await sign(await registry.nonces(_signer), _signer, { t: "string", v: serviceNames[0] }),
+        _signer,
+      );
+      const data = encodeMockFunctionCall("😂");
+      const value = web3.utils.toWei("1", "wei");
+      const result = await registry.execute(
+        OPERATION_CALL,
+        mock.address,
+        value,
+        data,
+        serviceNames[0],
+        await sign(
+          await registry.nonces(_signer),
+          _signer,
+          { t: "uint256", v: OPERATION_CALL },
+          { t: "address", v: mock.address },
+          { t: "uint256", v: value },
+          { t: "bytes", v: data },
+          { t: "string", v: serviceNames[0] },
+        ),
+        _signer,
+        { value },
+      );
+      expect(result.receipt.status).to.be.equal(true);
+      expect(await mock.bar()).to.be.equal("😂");
+      expect(await web3.eth.getBalance(mock.address)).to.be.bignumber.equal(value);
     });
   });
 });

--- a/test/registry.js
+++ b/test/registry.js
@@ -1,0 +1,57 @@
+const Registry = artifacts.require("Registry");
+const { expect } = require("chai");
+const { BN, expectEvent } = require("@openzeppelin/test-helpers");
+const { web3 } = require("@openzeppelin/test-helpers/src/setup");
+
+/*
+ * uncomment accounts to access the test accounts made available by the
+ * Ethereum client
+ * See docs: https://www.trufflesuite.com/docs/truffle/testing/writing-tests-in-javascript
+ */
+async function sign(nonce, signer, ...data) {
+  console.log("signed data", data);
+  let hash = web3.utils.soliditySha3(...data); // remove 0x prefix
+  console.log("hash1", hash, nonce.toString());
+  console.log("hash11", web3.utils.soliditySha3({ t: "string", v: "service1" }));
+  hash = web3.utils.soliditySha3({ t: "uint256", v: nonce }, { t: "bytes32", v: hash });
+  console.log("hash2", hash);
+  // hash = web3.utils.soliditySha3({t: "string", v: "\x19Ethereum Signed Message:\n32"}, {t: "bytes32", v: hash});
+  // console.log('hash3', hash)
+  return await web3.eth.sign(hash, signer);
+}
+
+contract("Registry", function ([_owner, _signer]) {
+  let registry;
+  let signer;
+  const password = "password";
+  beforeEach(async function () {
+    registry = await Registry.deployed();
+    // signer = await web3.eth.personal.newAccount(password);
+    // console.log("new account", signer)
+  });
+
+  context("Meta", function () {
+    it("should get name", async function () {
+      expect(await registry.name()).to.be.equal("Valory Registry");
+    });
+
+    it("should get symbol", async function () {
+      expect(await registry.symbol()).to.be.equal("VRT");
+    });
+  });
+
+  context("Service", function () {
+    it("should register a service", async function () {
+      const serviceName = "service1";
+      const signature = await sign(await registry.nonces(_signer), _signer, { t: "string", v: serviceName });
+      console.log("signature", signature);
+      const result = await registry.registerService(serviceName, signature, _signer);
+      console.log("result", result);
+      expect(result.receipt.status).to.be.equal(true);
+      expectEvent(result.receipt, "ServiceRegistered", {
+        name: serviceName,
+        owner: _signer,
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Summary Of Changes

This PR implement a NFT Registry as designed in issue #1 
(See more in the updated README.)

**NOTE:** The project was configured in `solc v0.8.6` & `javascript`

⚠️ The implementation is in experimenting, that means it involves seemingly inefficient logic and feature, in order to test various approaches for experiment purpose.

### Technical Considerations

1. `EnumerableSet`
   In order to track many to many relationship between token and service, I needed a keyed struct of mapping. It's still unclear about their exactly meaning and use.
   Right now, it uses Openzeppelin's `EnumerableSet` to store a) all, but not duplicated token id array for each service, b) all, but not duplicated service name array for each token.
   _**NOTE:** Because of it, it requires the service name to be less than or equal 32 bytes, since it is used as `EnumerableSet.Bytes32Set`_
2. Meta-transaction
   Every external function only accepts meta transactions. Thus, the sender must provide the signature which is signed by the real signer of the transaction.
3. `ecrecover` malleability 😵 vs `web3.eth.sign`
   `ecrecover` requires `v` to be `27` or `28`, however `web3.eth.sign` generates `0` or `1` for `v`.
   I couldn't test `web3.eth.personal.sign`, since it doesn't supported in geth network.
   So, in order to recover the signer certainly, I needed to adjust that `v`. See in the source code.
4. Redundant Heavy Function Modifier vs Optimization - "Stack too deep error" 🤕
   Since every external function accepts meta transaction, I tried to use sign verification logic as a common function modifier.
   But the logic is very intensive, also function modifier duplicates the body of each used function.
   Resulting a) "Out of Gas" error at deployment, or "Stack too deep" compile error inside functions.
   So, I switched sign verification logic to a private function, use the directly instead of modifier, those two issues have been fixed.
5. Unsupported External Calls
   The current implementation supports only contract `call`.
   Right now, `delegatecall`, `create` and `create2` are not supported.
6. `web3` BN bug in `expectEvent`
   When the transaction has `indexed uint256` event parameter in its log, `expectEvent` doesn't work properly.
   To solve it, convert the bignumber string by using `web3.utils.toBN()`, and use it to `expect`
7. Upcoming Features
   Some useful features have not been implemented. Those are necessary to make the registry fully working.
   - Public queries for services, tokens and their many to many relationships
   - More external operation types
   - Optimization


### Testing Notes

#### Install Truffle cli

```
npm install -g truffle
```

#### Install Dependencies

```
npm install
```

#### Run Tests

Launch Ganache then run:

```
npm run test
```

or test in truffle console

You should see the logs like:

```
truffle(develop)> test
Using network 'develop'.


Compiling your contracts...
===========================
> Everything is up to date, there is nothing to compile.



  Contract: Registry
    Metadata
      √ should get name (172ms)
      √ should get symbol (136ms)
    Meta-transaction
      √ should verify signature (405ms)
      √ should revert when an invalid signer provided (681ms)
    Service
      register
        √ should register a service (378ms)
        √ should revert if the service exists already (841ms)
      unregister
        √ should unregister a service (762ms)
        √ should revert if the service doesn't exist (483ms)
        √ should revert when the signer has no permission (817ms)
    Token
      register
        √ should register a token (571ms)
        √ should register a token and add to a service (1136ms)
        √ should revert if the given service doesn't exist (406ms)
      unregister
        √ should unregister a token (1001ms)
        √ should revert if the token doesn't exist (564ms)
        √ should revert when the signer has no permission (735ms)
    Token-Service Relationship
      √ should use a token for a service (1326ms)
      √ should revert if the service doesn't exist (807ms)
      √ should unuse a token for a service (1809ms)
      √ should revert if the token doesn't exist (1040ms)
    execute
      √ should revert if the signer has no permission (1009ms)
      √ should revert if the unsupported operation requested (954ms)
      √ should external call (1067ms)


  22 passing (31s)

```


### Deployment Notes
- [x] New Dependencies
- [x] New Migrations
- [x] New API Changes

Closes #1 